### PR TITLE
Removes unneeded `crit_id` table. #24

### DIFF
--- a/dbschema.sql
+++ b/dbschema.sql
@@ -1,6 +1,7 @@
 CREATE TABLE `crits` (
     `id` int(11) NOT NULL AUTO_INCREMENT,
     `user_id` int(11) NOT NULL,
+	`crit_reply_id` INT(11) NULL,
     `message` text NOT NULL,
     `created_on` datetime NOT NULL DEFAULT current_timestamp(),
     PRIMARY KEY (`id`)

--- a/dbschema.sql
+++ b/dbschema.sql
@@ -1,12 +1,10 @@
 CREATE TABLE `crits` (
     `id` int(11) NOT NULL AUTO_INCREMENT,
     `user_id` int(11) NOT NULL,
-    `crit_id` int(11) DEFAULT NULL,
     `message` text NOT NULL,
     `created_on` datetime NOT NULL DEFAULT current_timestamp(),
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;	
-
 
 CREATE TABLE `crit_likes` (
     `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Closes #24 

# Everyone must run the following code in their database to grab this change:

`ALTER TABLE crits RENAME COLUMN crit_id TO crit_reply_id ;`